### PR TITLE
All web service callbacks are now called on the main thread

### DIFF
--- a/ios/ios/src/Web Services/CMWebService.m
+++ b/ios/ios/src/Web Services/CMWebService.m
@@ -626,9 +626,8 @@ NSString * const YAJLErrorKey = @"YAJLErrorKey";
         }
         
         if (callback != nil) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                callback([responseBody objectForKey:@"success"], [responseBody objectForKey:@"errors"], $num([[responseBody objectForKey:@"success"] count]));
-            });
+            void (^block)() = ^{ callback([responseBody objectForKey:@"success"], [responseBody objectForKey:@"errors"], $num([[responseBody objectForKey:@"success"] count])); };
+            [self performSelectorOnMainThread:@selector(performBlock:) withObject:block waitUntilDone:YES];
         }
     };
 
@@ -668,9 +667,8 @@ NSString * const YAJLErrorKey = @"YAJLErrorKey";
         }
         
         if (callback != nil) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                callback(resultCode, responseBody);
-            });
+            void (^block)() = ^{ callback(resultCode, responseBody); };
+            [self performSelectorOnMainThread:@selector(performBlock:) withObject:block waitUntilDone:YES];
         }
     };
 
@@ -720,9 +718,8 @@ NSString * const YAJLErrorKey = @"YAJLErrorKey";
         if (error) {
             NSLog(@"CloudMine *** Unexpected error occurred during object request. (%@)", [error localizedDescription]);
             if (errorHandler != nil) {
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    errorHandler(error);
-                });
+                void (^block)() = ^{ errorHandler(error); };
+                [self performSelectorOnMainThread:@selector(performBlock:) withObject:block waitUntilDone:YES];
             }
             return;
         }
@@ -758,9 +755,8 @@ NSString * const YAJLErrorKey = @"YAJLErrorKey";
         }
         
         if (successHandler != nil) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                successHandler(successes, errors, meta, snippetResult, count, [response allHeaderFields]);
-            });
+            void (^block)() = ^{ successHandler(successes, errors, meta, snippetResult, count, [response allHeaderFields]); };
+            [self performSelectorOnMainThread:@selector(performBlock:) withObject:block waitUntilDone:YES];
         }
     };
 
@@ -774,9 +770,8 @@ NSString * const YAJLErrorKey = @"YAJLErrorKey";
     void (^responseBlock)() = ^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
          if ([response statusCode] == 200) {
             if (successHandler != nil) {
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    successHandler(data, [[response allHeaderFields] objectForKey:@"Content-Type"], [response allHeaderFields]);
-                });
+                void (^block)() = ^{ successHandler(data, [[response allHeaderFields] objectForKey:@"Content-Type"], [response allHeaderFields]); };
+                [self performSelectorOnMainThread:@selector(performBlock:) withObject:block waitUntilDone:YES];
             }
         } else {
             if ([[error domain] isEqualToString:NSURLErrorDomain]) {
@@ -808,9 +803,8 @@ NSString * const YAJLErrorKey = @"YAJLErrorKey";
             
             NSLog(@"CloudMine *** Unexpected error occurred during binary download request. (%@)", [error localizedDescription]);
             if (errorHandler != nil) {
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    errorHandler(error);
-                });
+                void (^block)() = ^{ errorHandler(error); };
+                [self performSelectorOnMainThread:@selector(performBlock:) withObject:block waitUntilDone:YES];
             }
         }
     };
@@ -861,9 +855,8 @@ NSString * const YAJLErrorKey = @"YAJLErrorKey";
         if (error) {
             NSLog(@"CloudMine *** Unexpected error occurred during binary upload request. (%@)", [error localizedDescription]);
             if (errorHandler != nil) {
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    errorHandler(error);
-                });
+                void (^block)() = ^{ errorHandler(error); };
+                [self performSelectorOnMainThread:@selector(performBlock:) withObject:block waitUntilDone:YES];
             }
             return;
         }
@@ -878,13 +871,16 @@ NSString * const YAJLErrorKey = @"YAJLErrorKey";
         }
         
         if (successHandler != nil) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                successHandler([response statusCode] == 201 ? CMFileCreated : CMFileUpdated, key, snippetResult, [response allHeaderFields]);
-            });
+            void (^block)() = ^{ successHandler([response statusCode] == 201 ? CMFileCreated : CMFileUpdated, key, snippetResult, [response allHeaderFields]); };
+            [self performSelectorOnMainThread:@selector(performBlock:) withObject:block waitUntilDone:YES];
         }
     };
-
+    
     [NSURLConnection sendAsynchronousRequest:request queue:self.networkQueue completionHandler:responseBlock];
+}
+
+- (void)performBlock:(void (^)())block {
+    block();
 }
 
 #pragma - Request construction


### PR DESCRIPTION
This makes sure all callbacks are called on the main thread, using Grand Central Dispatch. The API used is available for iOS 4 and above (just as blocks are). This is thoroughly tested in the integration tests. Make sure to merge the tests if/when you merge this:

https://github.com/cloudmine/cloudmine-ios-integration/pull/2

References:
https://app.asana.com/0/1082392067816/1140398789626
http://developer.apple.com/library/ios/documentation/General/Conceptual/ConcurrencyProgrammingGuide/OperationQueues/OperationQueues.html#//apple_ref/doc/uid/TP40008091-CH102-SW15
