### PR TITLE
specifying a CONFIGURATION_BUILD_DIR for the "Build Static Libs"

### DIFF
--- a/ios/cloudmine-ios.xcodeproj/project.pbxproj
+++ b/ios/cloudmine-ios.xcodeproj/project.pbxproj
@@ -864,7 +864,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "xcodebuild -project ${PROJECT_NAME}.xcodeproj -sdk iphonesimulator -target ${PROJECT_NAME} -configuration ${CONFIGURATION} clean build\n\nxcodebuild -project ${PROJECT_NAME}.xcodeproj -sdk iphoneos -target ${PROJECT_NAME} -configuration ${CONFIGURATION} clean build";
+			shellScript = "xcodebuild -project ${PROJECT_NAME}.xcodeproj -sdk iphonesimulator -target ${PROJECT_NAME} -configuration ${CONFIGURATION} clean build CONFIGURATION_BUILD_DIR=${BUILD_DIR}/${CONFIGURATION}-iphonesimulator\n\nxcodebuild -project ${PROJECT_NAME}.xcodeproj -sdk iphoneos -target ${PROJECT_NAME} -configuration ${CONFIGURATION} clean build CONFIGURATION_BUILD_DIR=${BUILD_DIR}/${CONFIGURATION}-iphoneos";
 		};
 		7A87315014BB0A5F000D6DEA /* Build universal binary */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
specifying a CONFIGURATION_BUILD_DIR for the "Build Static Libs" build phase. Allows the build scripts to run, without requiring Xcode to build to the "legacy" locations.
