### PR TITLE
CMFile would never actual write itself to the cache

### DIFF
--- a/ios/ios/src/Persisted Objects/CMFile.m
+++ b/ios/ios/src/Persisted Objects/CMFile.m
@@ -178,7 +178,7 @@ NSString * const _mimeTypeKey = @"mime";
 }
 
 - (BOOL)writeToLocation:(NSURL *)url options:(NSFileWrapperWritingOptions)options {
-    return [NSKeyedArchiver archiveRootObject:self toFile:[url absoluteString]];
+    return [NSKeyedArchiver archiveRootObject:self toFile:[url path]];
 }
 
 - (BOOL)writeToCache {


### PR DESCRIPTION
writeToLocation would always fail, because NSKeyArchiver archiveRootObject:toFile required a file path, not a URL string.
