### PR TITLE
Added encode/decodeBytesForKey to the CMObjectEncoder/Decoder classes

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
   - AFNetworking (2.5.4):
-    - AFNetworking/NSURLConnection
-    - AFNetworking/NSURLSession
-    - AFNetworking/Reachability
-    - AFNetworking/Security
-    - AFNetworking/Serialization
-    - AFNetworking/UIKit
+    - AFNetworking/NSURLConnection (= 2.5.4)
+    - AFNetworking/NSURLSession (= 2.5.4)
+    - AFNetworking/Reachability (= 2.5.4)
+    - AFNetworking/Security (= 2.5.4)
+    - AFNetworking/Serialization (= 2.5.4)
+    - AFNetworking/UIKit (= 2.5.4)
   - AFNetworking/NSURLConnection (2.5.4):
     - AFNetworking/Reachability
     - AFNetworking/Security
@@ -36,4 +36,4 @@ SPEC CHECKSUMS:
   MAObjCRuntime: a6a1d95acbfa3784d66cb35bd42904e47943b488
   NSData+Base64: 4e84902c4db907a15673474677e57763ef3903e4
 
-COCOAPODS: 0.34.2
+COCOAPODS: 0.39.0

--- a/ios/cloudmine-ios.xcodeproj/project.pbxproj
+++ b/ios/cloudmine-ios.xcodeproj/project.pbxproj
@@ -335,8 +335,8 @@
 		7AABA2E41480549A00FD52A0 /* CMObjectEncoderSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMObjectEncoderSpec.m; sourceTree = "<group>"; };
 		7AABA2E61480598300FD52A0 /* NSString+UUID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+UUID.h"; sourceTree = "<group>"; };
 		7AABA2E71480598300FD52A0 /* NSString+UUID.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+UUID.m"; sourceTree = "<group>"; };
-		7AABA2FB14818DCA00FD52A0 /* CMObjectDecoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = CMObjectDecoder.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		7AABA2FC14818DCA00FD52A0 /* CMObjectDecoder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = CMObjectDecoder.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		7AABA2FB14818DCA00FD52A0 /* CMObjectDecoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = CMObjectDecoder.h; sourceTree = "<group>"; };
+		7AABA2FC14818DCA00FD52A0 /* CMObjectDecoder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = CMObjectDecoder.m; sourceTree = "<group>"; };
 		7AABA2FE14818DCA00FD52A0 /* CMObjectEncoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CMObjectEncoder.h; sourceTree = "<group>"; };
 		7AABA2FF14818DCA00FD52A0 /* CMObjectEncoder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = CMObjectEncoder.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		7AAFB49A158017450066B4A4 /* CMMimeTypeSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMMimeTypeSpec.m; sourceTree = "<group>"; };
@@ -954,6 +954,7 @@
 				7AB4AB6C145DC5D8006AEF67 /* Resources */,
 				BAA7BC150F1A4FDD944A2FD4 /* Copy Pods Resources */,
 				AABEE9F719081815007A26BA /* Delete All Users and Objects */,
+				9618D865B76C75FFA0458E54 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1065,6 +1066,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-cloudmine-ios/Pods-cloudmine-ios-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9618D865B76C75FFA0458E54 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-cloudmine-iosTests/Pods-cloudmine-iosTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		AABEE9F719081815007A26BA /* Delete All Users and Objects */ = {

--- a/ios/cloudmine-ios.xcodeproj/xcshareddata/xcschemes/CloudMine Universal Framework.xcscheme
+++ b/ios/cloudmine-ios.xcodeproj/xcshareddata/xcschemes/CloudMine Universal Framework.xcscheme
@@ -23,21 +23,25 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Test"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Release">
+      codeCoverageEnabled = "YES">
       <Testables>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -52,10 +56,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction

--- a/ios/ios/src/Web Services/Decoding/CMObjectDecoder.m
+++ b/ios/ios/src/Web Services/Decoding/CMObjectDecoder.m
@@ -90,14 +90,16 @@
     return ([_dictionaryRepresentation objectForKey:key] != nil);
 }
 
-- (const uint8_t *)decodeBytesForKey:(NSString *)key {
+- (const uint8_t *)decodeBytesForKey:(NSString *)key returnedLength:(NSUInteger *)lengthp {
     if(![self containsValueForKey:key]) {
         return 0;
     }
     
     id val = [_dictionaryRepresentation valueForKey:key];
     if (val != nil && val != [NSNull null]) {
-        return [[_dictionaryRepresentation valueForKey:key] bytes];
+        NSString *stringRepresentation = (NSString *)val;
+        NSData *bytesObject = [stringRepresentation dataUsingEncoding:NSUTF8StringEncoding];
+        return [bytesObject bytes];
     }
     return 0;
 }

--- a/ios/ios/src/Web Services/Decoding/CMObjectDecoder.m
+++ b/ios/ios/src/Web Services/Decoding/CMObjectDecoder.m
@@ -90,6 +90,18 @@
     return ([_dictionaryRepresentation objectForKey:key] != nil);
 }
 
+- (const uint8_t *)decodeBytesForKey:(NSString *)key {
+    if(![self containsValueForKey:key]) {
+        return 0;
+    }
+    
+    id val = [_dictionaryRepresentation valueForKey:key];
+    if (val != nil && val != [NSNull null]) {
+        return [[_dictionaryRepresentation valueForKey:key] bytes];
+    }
+    return 0;
+}
+
 - (BOOL)decodeBoolForKey:(NSString *)key {
     if (![self containsValueForKey:key]) {
         return NO;

--- a/ios/ios/src/Web Services/Decoding/CMObjectDecoder.m
+++ b/ios/ios/src/Web Services/Decoding/CMObjectDecoder.m
@@ -97,9 +97,12 @@
     
     id val = [_dictionaryRepresentation valueForKey:key];
     if (val != nil && val != [NSNull null]) {
-        NSString *stringRepresentation = (NSString *)val;
-        NSData *bytesObject = [stringRepresentation dataUsingEncoding:NSUTF8StringEncoding];
-        return [bytesObject bytes];
+        NSData *data = [[NSData alloc] initWithBase64EncodedString:val options:0];
+        NSUInteger dataLength = [data length];
+        uint8_t *bytes = calloc(dataLength, sizeof(uint8_t));
+        [data getBytes:bytes length:dataLength];
+        *lengthp = dataLength;
+        return bytes;
     }
     return 0;
 }

--- a/ios/ios/src/Web Services/Encoding/CMObjectEncoder.m
+++ b/ios/ios/src/Web Services/Encoding/CMObjectEncoder.m
@@ -91,8 +91,9 @@
 
 - (void) encodeBytes:(const uint8_t *)bytesp length:(NSUInteger)lenv forKey:(NSString *)key;
 {
-    NSString *stringObj = [[NSString alloc] initWithBytes:bytesp length:lenv encoding:NSASCIIStringEncoding];
-    [_encodedData setObject:stringObj forKey:key];
+    NSData *data = [NSData dataWithBytes:bytesp length:lenv];
+    NSString *base64EncodedString = [data base64EncodedStringWithOptions:0];
+    [_encodedData setObject:base64EncodedString forKey:key];
 }
 
 - (void)encodeBool:(BOOL)boolv forKey:(NSString *)key;

--- a/ios/ios/src/Web Services/Encoding/CMObjectEncoder.m
+++ b/ios/ios/src/Web Services/Encoding/CMObjectEncoder.m
@@ -89,6 +89,12 @@
     return ([_encodedData objectForKey:key] != nil);
 }
 
+- (void) encodeBytes:(const uint8_t *)bytesp length:(NSUInteger)lenv forKey:(NSString *)key;
+{
+    NSString *stringObj = [[NSString alloc] initWithBytes:bytesp length:lenv encoding:NSASCIIStringEncoding];
+    [_encodedData setObject:stringObj forKey:key];
+}
+
 - (void)encodeBool:(BOOL)boolv forKey:(NSString *)key;
 {
     [_encodedData setObject:[NSNumber numberWithBool:boolv] forKey:key];


### PR DESCRIPTION
This is an attempt to add `encodeBytesForKey` and `decodeBytesForKey` to the `CMObjectEncoder` and `CMObjectDecoder` classes respectfully. I'm using it in conjunction with the following [class](https://gist.github.com/natevecc/08fa725e151a16c804d3) to try and encode and decode `ORKResult` objects for use with ResearchKit.

Encoding appears to be working but decoding the response doesn't appear to be working correctly. Any advice would be greatly appreciated!
