### PR TITLE
Vendor in the MAObjCRuntime Dependency

### DIFF
--- a/CloudMine.podspec
+++ b/CloudMine.podspec
@@ -8,11 +8,15 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '8.0'
   s.source       = { :git => "https://github.com/cloudmine/cloudmine-ios.git", :tag => "v#{s.version}" }
   s.source_files  = 'ios/ios/src/**/*.{h,m}'
-  s.exclude_files = 'NSString+UUID.h', 'NSURL+QueryParameterAdditions.h', 'CMObject+Private.h', 'CMObjectClassNameRegistry.h'
+  s.exclude_files = 'NSString+UUID.h', 'NSURL+QueryParameterAdditions.h', 'CMObject+Private.h', 'CMObjectClassNameRegistry.h', 'MARTNSObject.{h,m}', 'RT*.{h,m}'
   s.frameworks = 'UIKit', 'CoreGraphics', 'MobileCoreServices', 'SystemConfiguration', 'CFNetwork', 'Foundation', 'CoreFoundation', 'CoreLocation', 'Social', 'Accounts'
   s.libraries = 'z'
   s.requires_arc = true
   s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' }
+  s.subspec 'no-arc' do |sna|
+    sna.requires_arc = false
+    sna.source_files = 'ios/ios/src/**/MARTNSObject*.{h,m}', 'ios/ios/src/**/RT*.{h,m}'
+  end
 
   s.dependency 'AFNetworking', '~> 2.6.3'
 

--- a/CloudMine.podspec
+++ b/CloudMine.podspec
@@ -15,7 +15,6 @@ Pod::Spec.new do |s|
   s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' }
 
   s.dependency 'AFNetworking', '~> 2.6.3'
-  s.dependency 'MAObjCRuntime', '~> 0.0.1'
 
   s.prefix_header_contents = '#import <SystemConfiguration/SystemConfiguration.h>', '#import <MobileCoreServices/MobileCoreServices.h>'
 end

--- a/Podfile
+++ b/Podfile
@@ -31,7 +31,6 @@ inhibit_all_warnings!
 #
 target "cloudmine-ios" do
   pod 'AFNetworking', '2.6.3'
-  pod 'MAObjCRuntime', '0.0.1'
 end
 
 #

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -21,19 +21,16 @@ PODS:
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
   - Kiwi (2.3.1)
-  - MAObjCRuntime (0.0.1)
   - NSData+Base64 (1.0.0)
 
 DEPENDENCIES:
   - AFNetworking (= 2.6.3)
   - Kiwi (= 2.3.1)
-  - MAObjCRuntime (= 0.0.1)
   - NSData+Base64 (= 1.0.0)
 
 SPEC CHECKSUMS:
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
   Kiwi: f038a6c61f7a9e4d7766bff5717aa3b3fdb75f55
-  MAObjCRuntime: a6a1d95acbfa3784d66cb35bd42904e47943b488
   NSData+Base64: 4e84902c4db907a15673474677e57763ef3903e4
 
 COCOAPODS: 0.39.0

--- a/ios/cloudmine-ios.xcodeproj/project.pbxproj
+++ b/ios/cloudmine-ios.xcodeproj/project.pbxproj
@@ -187,6 +187,13 @@
 		AAE9220F194B8B7B004DA1AC /* venues.plist in Resources */ = {isa = PBXBuildFile; fileRef = AAE9220E194B8B7B004DA1AC /* venues.plist */; };
 		AAE92211194B923D004DA1AC /* CMWebServiceIntegrationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = AAE92210194B923D004DA1AC /* CMWebServiceIntegrationSpec.m */; };
 		AAFB0B8D194B45D5008F2B68 /* CMResponseSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = AAFB0B8C194B45D5008F2B68 /* CMResponseSpec.m */; };
+		B4AD7C521C80FF6D00D9F1D1 /* MARTNSObject.m in Sources */ = {isa = PBXBuildFile; fileRef = B4AD7C461C80FF6C00D9F1D1 /* MARTNSObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		B4AD7C531C80FF6D00D9F1D1 /* README.markdown in Sources */ = {isa = PBXBuildFile; fileRef = B4AD7C471C80FF6C00D9F1D1 /* README.markdown */; };
+		B4AD7C541C80FF6D00D9F1D1 /* RTIvar.m in Sources */ = {isa = PBXBuildFile; fileRef = B4AD7C491C80FF6C00D9F1D1 /* RTIvar.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		B4AD7C551C80FF6D00D9F1D1 /* RTMethod.m in Sources */ = {isa = PBXBuildFile; fileRef = B4AD7C4B1C80FF6C00D9F1D1 /* RTMethod.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		B4AD7C561C80FF6D00D9F1D1 /* RTProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = B4AD7C4D1C80FF6C00D9F1D1 /* RTProperty.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		B4AD7C571C80FF6D00D9F1D1 /* RTProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = B4AD7C4F1C80FF6C00D9F1D1 /* RTProtocol.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		B4AD7C581C80FF6D00D9F1D1 /* RTUnregisteredClass.m in Sources */ = {isa = PBXBuildFile; fileRef = B4AD7C511C80FF6C00D9F1D1 /* RTUnregisteredClass.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		D039C16715BDEB77005CCD33 /* CMACLSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = D039C16615BDEB77005CCD33 /* CMACLSpec.m */; };
 		D039C16A15BEEB44005CCD33 /* CMACLFetchResponseSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = D039C16915BEEB44005CCD33 /* CMACLFetchResponseSpec.m */; };
 		D03A4D5C15B48D2200A956BC /* CMACLFetchResponse.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D042C2E915AF41F100A88888 /* CMACLFetchResponse.h */; };
@@ -450,6 +457,20 @@
 		AAFB0B8C194B45D5008F2B68 /* CMResponseSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMResponseSpec.m; sourceTree = "<group>"; };
 		AF2E9ED71CBDDC65DC88789E /* Pods-cloudmine-iosTests.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-cloudmine-iosTests.test.xcconfig"; path = "../Pods/Target Support Files/Pods-cloudmine-iosTests/Pods-cloudmine-iosTests.test.xcconfig"; sourceTree = "<group>"; };
 		B2A33E73BEDE10A94973E9FE /* Pods-cloudmine-ios.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-cloudmine-ios.release.xcconfig"; path = "../Pods/Target Support Files/Pods-cloudmine-ios/Pods-cloudmine-ios.release.xcconfig"; sourceTree = "<group>"; };
+		B4AD7C441C80FF6C00D9F1D1 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		B4AD7C451C80FF6C00D9F1D1 /* MARTNSObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MARTNSObject.h; sourceTree = "<group>"; };
+		B4AD7C461C80FF6C00D9F1D1 /* MARTNSObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MARTNSObject.m; sourceTree = "<group>"; };
+		B4AD7C471C80FF6C00D9F1D1 /* README.markdown */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.markdown; sourceTree = "<group>"; };
+		B4AD7C481C80FF6C00D9F1D1 /* RTIvar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTIvar.h; sourceTree = "<group>"; };
+		B4AD7C491C80FF6C00D9F1D1 /* RTIvar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RTIvar.m; sourceTree = "<group>"; };
+		B4AD7C4A1C80FF6C00D9F1D1 /* RTMethod.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTMethod.h; sourceTree = "<group>"; };
+		B4AD7C4B1C80FF6C00D9F1D1 /* RTMethod.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RTMethod.m; sourceTree = "<group>"; };
+		B4AD7C4C1C80FF6C00D9F1D1 /* RTProperty.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTProperty.h; sourceTree = "<group>"; };
+		B4AD7C4D1C80FF6C00D9F1D1 /* RTProperty.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RTProperty.m; sourceTree = "<group>"; };
+		B4AD7C4E1C80FF6C00D9F1D1 /* RTProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTProtocol.h; sourceTree = "<group>"; };
+		B4AD7C4F1C80FF6C00D9F1D1 /* RTProtocol.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RTProtocol.m; sourceTree = "<group>"; };
+		B4AD7C501C80FF6C00D9F1D1 /* RTUnregisteredClass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTUnregisteredClass.h; sourceTree = "<group>"; };
+		B4AD7C511C80FF6C00D9F1D1 /* RTUnregisteredClass.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RTUnregisteredClass.m; sourceTree = "<group>"; };
 		C3444874F77B35F0544725D1 /* Pods-cloudmine-ios.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-cloudmine-ios.test.xcconfig"; path = "../Pods/Target Support Files/Pods-cloudmine-ios/Pods-cloudmine-ios.test.xcconfig"; sourceTree = "<group>"; };
 		D039C16615BDEB77005CCD33 /* CMACLSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = CMACLSpec.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		D039C16915BEEB44005CCD33 /* CMACLFetchResponseSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = CMACLFetchResponseSpec.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
@@ -718,6 +739,7 @@
 				7AD36F7B146C64F300DD4734 /* Web Services */,
 				7A7E31C514C88F760091F1E3 /* Storage */,
 				AA00CECF1886E19700F9958C /* UIAdditions */,
+				B4AD7C431C80FEB300D9F1D1 /* Vendor */,
 			);
 			path = src;
 			sourceTree = "<group>";
@@ -920,6 +942,27 @@
 				AAE92210194B923D004DA1AC /* CMWebServiceIntegrationSpec.m */,
 			);
 			name = integration;
+			sourceTree = "<group>";
+		};
+		B4AD7C431C80FEB300D9F1D1 /* Vendor */ = {
+			isa = PBXGroup;
+			children = (
+				B4AD7C441C80FF6C00D9F1D1 /* LICENSE */,
+				B4AD7C451C80FF6C00D9F1D1 /* MARTNSObject.h */,
+				B4AD7C461C80FF6C00D9F1D1 /* MARTNSObject.m */,
+				B4AD7C471C80FF6C00D9F1D1 /* README.markdown */,
+				B4AD7C481C80FF6C00D9F1D1 /* RTIvar.h */,
+				B4AD7C491C80FF6C00D9F1D1 /* RTIvar.m */,
+				B4AD7C4A1C80FF6C00D9F1D1 /* RTMethod.h */,
+				B4AD7C4B1C80FF6C00D9F1D1 /* RTMethod.m */,
+				B4AD7C4C1C80FF6C00D9F1D1 /* RTProperty.h */,
+				B4AD7C4D1C80FF6C00D9F1D1 /* RTProperty.m */,
+				B4AD7C4E1C80FF6C00D9F1D1 /* RTProtocol.h */,
+				B4AD7C4F1C80FF6C00D9F1D1 /* RTProtocol.m */,
+				B4AD7C501C80FF6C00D9F1D1 /* RTUnregisteredClass.h */,
+				B4AD7C511C80FF6C00D9F1D1 /* RTUnregisteredClass.m */,
+			);
+			path = Vendor;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1151,6 +1194,7 @@
 				7AD36F7F146C650500DD4734 /* CMWebService.m in Sources */,
 				7AD36F85146CA4AC00DD4734 /* CMAPICredentials.m in Sources */,
 				7AD36F8E146CB6A600DD4734 /* NSURL+QueryParameterAdditions.m in Sources */,
+				B4AD7C571C80FF6D00D9F1D1 /* RTProtocol.m in Sources */,
 				7A04E86C147D8435006E00AB /* CMServerFunction.m in Sources */,
 				7AABA2E91480598300FD52A0 /* NSString+UUID.m in Sources */,
 				7AABA30114818DCA00FD52A0 /* CMObjectDecoder.m in Sources */,
@@ -1160,11 +1204,14 @@
 				7AD9221D14CF47360032DDDE /* CMPagingDescriptor.m in Sources */,
 				7AD9222414D06B9A0032DDDE /* CMStoreOptions.m in Sources */,
 				AAA05FC0183A756B009652C9 /* CMPaymentResponse.m in Sources */,
+				B4AD7C581C80FF6D00D9F1D1 /* RTUnregisteredClass.m in Sources */,
 				7A58CC2214F1B544003E864B /* CMMimeType.m in Sources */,
 				7AE2848B1562C3C8003E8A8F /* CMSortDescriptor.m in Sources */,
+				B4AD7C531C80FF6D00D9F1D1 /* README.markdown in Sources */,
 				65199EC2156A7D9500267EC6 /* CMDeleteResponse.m in Sources */,
 				65199EC3156A7D9500267EC6 /* CMFileFetchResponse.m in Sources */,
 				65199EC4156A7D9500267EC6 /* CMFileUploadResponse.m in Sources */,
+				B4AD7C561C80FF6D00D9F1D1 /* RTProperty.m in Sources */,
 				65199EC5156A7D9500267EC6 /* CMObjectFetchResponse.m in Sources */,
 				65199EC6156A7D9500267EC6 /* CMObjectUploadResponse.m in Sources */,
 				65199EC7156A7D9500267EC6 /* CMResponseMetadata.m in Sources */,
@@ -1175,6 +1222,7 @@
 				AA00CED31886E1C700F9958C /* UIImageView+CloudMine.m in Sources */,
 				7AFDFE42158E959B00388D6E /* CMDate.m in Sources */,
 				7AFDFE43158E959B00388D6E /* CMFile.m in Sources */,
+				B4AD7C551C80FF6D00D9F1D1 /* RTMethod.m in Sources */,
 				7AFDFE44158E959B00388D6E /* CMGeoPoint.m in Sources */,
 				7AFDFE45158E959B00388D6E /* CMObject.m in Sources */,
 				AA025E46198BEA9E00284B5F /* CMSocialAccountChooser.m in Sources */,
@@ -1184,12 +1232,14 @@
 				AAA05FBE183A756B009652C9 /* CMCardPayment.m in Sources */,
 				7AFDFE4A158E965400388D6E /* CMActiveUser.m in Sources */,
 				7AF00BA015A8DC650070442A /* CMACL.m in Sources */,
+				B4AD7C521C80FF6D00D9F1D1 /* MARTNSObject.m in Sources */,
 				AAA05FB9183A756B009652C9 /* CMPaymentService.m in Sources */,
 				7AF00BA115A8DC650070442A /* CMUser.m in Sources */,
 				D042C2EB15AF41F100A88888 /* CMACLFetchResponse.m in Sources */,
 				AAA92FFE181972DA0064F773 /* CMTools.m in Sources */,
 				71E886B716516C3D0060C217 /* CMSocialLoginViewController.m in Sources */,
 				AAB2E0B0167B94CF00D2C699 /* CMAppDelegateBase.m in Sources */,
+				B4AD7C541C80FF6D00D9F1D1 /* RTIvar.m in Sources */,
 				AAC1D8F116DD4BCC002A7DC0 /* CMChannelResponse.m in Sources */,
 				AAC1D8F416DD51FB002A7DC0 /* CMResponse.m in Sources */,
 				AAA92FF4181966370064F773 /* NSDictionary+CMJSON.m in Sources */,
@@ -1439,7 +1489,6 @@
 					"$(inherited)",
 					"-all_load",
 					"-l\"AFNetworking\"",
-					"-l\"MAObjCRuntime\"",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cloudmine.sdk.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "cloudmine-iosTests";
@@ -1466,7 +1515,6 @@
 					"$(inherited)",
 					"-all_load",
 					"-l\"AFNetworking\"",
-					"-l\"MAObjCRuntime\"",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cloudmine.sdk.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "cloudmine-iosTests";
@@ -1564,7 +1612,6 @@
 					"$(inherited)",
 					"-all_load",
 					"-l\"AFNetworking\"",
-					"-l\"MAObjCRuntime\"",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cloudmine.sdk.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "cloudmine-iosTests";

--- a/ios/ios/src/Vendor/LICENSE
+++ b/ios/ios/src/Vendor/LICENSE
@@ -1,0 +1,15 @@
+MAObjCRuntime and all code associated with it is distributed under a BSD license, as listed below.
+
+
+Copyright (c) 2010, Michael Ash
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+Neither the name of Michael Ash nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ios/ios/src/Vendor/MARTNSObject.h
+++ b/ios/ios/src/Vendor/MARTNSObject.h
@@ -1,0 +1,47 @@
+
+#import <Foundation/Foundation.h>
+
+
+@class RTProtocol;
+@class RTIvar;
+@class RTProperty;
+@class RTMethod;
+@class RTUnregisteredClass;
+
+@interface NSObject (MARuntime)
+
+// includes the receiver
++ (NSArray *)rt_subclasses;
+
++ (RTUnregisteredClass *)rt_createUnregisteredSubclassNamed: (NSString *)name;
++ (Class)rt_createSubclassNamed: (NSString *)name;
++ (void)rt_destroyClass;
+
++ (BOOL)rt_isMetaClass;
++ (Class)rt_setSuperclass: (Class)newSuperclass;
++ (size_t)rt_instanceSize;
+
++ (NSArray *)rt_protocols;
+
++ (NSArray *)rt_methods;
++ (RTMethod *)rt_methodForSelector: (SEL)sel;
+
++ (void)rt_addMethod: (RTMethod *)method;
+
++ (NSArray *)rt_ivars;
++ (RTIvar *)rt_ivarForName: (NSString *)name;
+
++ (NSArray *)rt_properties;
++ (RTProperty *)rt_propertyForName: (NSString *)name;
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
++ (BOOL)rt_addProperty: (RTProperty *)property;
+#endif
+
+// Apple likes to fiddle with -class to hide their dynamic subclasses
+// e.g. KVO subclasses, so [obj class] can lie to you
+// rt_class is a direct call to object_getClass (which in turn
+// directly hits up the isa) so it will always tell the truth
+- (Class)rt_class;
+- (Class)rt_setClass: (Class)newClass;
+
+@end

--- a/ios/ios/src/Vendor/MARTNSObject.m
+++ b/ios/ios/src/Vendor/MARTNSObject.m
@@ -1,0 +1,180 @@
+
+#import "MARTNSObject.h"
+
+#import <objc/runtime.h>
+
+#import "RTProtocol.h"
+#import "RTIvar.h"
+#import "RTProperty.h"
+#import "RTMethod.h"
+#import "RTUnregisteredClass.h"
+
+
+@implementation NSObject (MARuntime)
+
++ (NSArray *)rt_subclasses
+{
+    Class *buffer = NULL;
+    
+    int count, size;
+    do
+    {
+        count = objc_getClassList(NULL, 0);
+        buffer = realloc(buffer, count * sizeof(*buffer));
+        size = objc_getClassList(buffer, count);
+    } while(size != count);
+    
+    NSMutableArray *array = [NSMutableArray array];
+    for(int i = 0; i < count; i++)
+    {
+        Class candidate = buffer[i];
+        Class superclass = candidate;
+        while(superclass)
+        {
+            if(superclass == self)
+            {
+                [array addObject: candidate];
+                break;
+            }
+            superclass = class_getSuperclass(superclass);
+        }
+    }
+    free(buffer);
+    return array;
+}
+
++ (RTUnregisteredClass *)rt_createUnregisteredSubclassNamed: (NSString *)name
+{
+    return [RTUnregisteredClass unregisteredClassWithName: name withSuperclass: self];
+}
+
++ (Class)rt_createSubclassNamed: (NSString *)name
+{
+    return [[self rt_createUnregisteredSubclassNamed: name] registerClass];
+}
+
++ (void)rt_destroyClass
+{
+    objc_disposeClassPair(self);
+}
+
++ (BOOL)rt_isMetaClass
+{
+    return class_isMetaClass(self);
+}
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#endif
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
++ (Class)rt_setSuperclass: (Class)newSuperclass
+{
+    return class_setSuperclass(self, newSuperclass);
+}
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
++ (size_t)rt_instanceSize
+{
+    return class_getInstanceSize(self);
+}
+
++ (NSArray *)rt_protocols
+{
+    unsigned int count;
+    Protocol **protocols = class_copyProtocolList(self, &count);
+    
+    NSMutableArray *array = [NSMutableArray array];
+    for(unsigned i = 0; i < count; i++)
+        [array addObject: [RTProtocol protocolWithObjCProtocol: protocols[i]]];
+    
+    free(protocols);
+    return array;
+}
+
++ (NSArray *)rt_methods
+{
+    unsigned int count;
+    Method *methods = class_copyMethodList(self, &count);
+    
+    NSMutableArray *array = [NSMutableArray array];
+    for(unsigned i = 0; i < count; i++)
+        [array addObject: [RTMethod methodWithObjCMethod: methods[i]]];
+    
+    free(methods);
+    return array;
+}
+
++ (RTMethod *)rt_methodForSelector: (SEL)sel
+{
+    Method m = class_getInstanceMethod(self, sel);
+    if(!m) return nil;
+    
+    return [RTMethod methodWithObjCMethod: m];
+}
+
++ (void)rt_addMethod: (RTMethod *)method
+{
+    class_addMethod(self, [method selector], [method implementation], [[method signature] UTF8String]);
+}
+
++ (NSArray *)rt_ivars
+{
+    unsigned int count;
+    Ivar *list = class_copyIvarList(self, &count);
+    
+    NSMutableArray *array = [NSMutableArray array];
+    for(unsigned i = 0; i < count; i++)
+        [array addObject: [RTIvar ivarWithObjCIvar: list[i]]];
+    
+    free(list);
+    return array;
+}
+
++ (RTIvar *)rt_ivarForName: (NSString *)name
+{
+    Ivar ivar = class_getInstanceVariable(self, [name UTF8String]);
+    if(!ivar) return nil;
+    return [RTIvar ivarWithObjCIvar: ivar];
+}
+
++ (NSArray *)rt_properties
+{
+    unsigned int count;
+    objc_property_t *list = class_copyPropertyList(self, &count);
+    
+    NSMutableArray *array = [NSMutableArray array];
+    for(unsigned i = 0; i < count; i++)
+        [array addObject: [RTProperty propertyWithObjCProperty: list[i]]];
+    
+    free(list);
+    return array;
+}
+
++ (RTProperty *)rt_propertyForName: (NSString *)name
+{
+    objc_property_t property = class_getProperty(self, [name UTF8String]);
+    if(!property) return nil;
+    return [RTProperty propertyWithObjCProperty: property];
+}
+
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
++ (BOOL)rt_addProperty: (RTProperty *)property
+{
+    return [property addToClass:self];
+}
+#endif
+
+- (Class)rt_class
+{
+    return object_getClass(self);
+}
+
+- (Class)rt_setClass: (Class)newClass
+{
+    return object_setClass(self, newClass);
+}
+
+@end
+

--- a/ios/ios/src/Vendor/README.markdown
+++ b/ios/ios/src/Vendor/README.markdown
@@ -1,0 +1,86 @@
+MAObjCRuntime
+-------------
+
+MAObjCRuntime is an ObjC wrapper around the Objective-C runtime APIs. If that's confusing, it provides a nice object-oriented interface around (some of) the C functions in /usr/include/objc.
+
+MAObjCRuntime is released under a BSD license. For the official license, see the LICENSE file.
+
+Quick Start
+-----------
+
+The action begins in `MARTNSObject.h`. Various methods are added to `NSObject` to allow querying and manipulation. Most of these are class methods, because they operate on classes. There are a couple of instance methods as well. All of these methods start with `rt_` to avoid name conflicts. The `RTMethod` and `RTIvar` classes are used to represent a single method and a single instance variable, respectively. Their use should be fairly obvious.
+
+Querying
+--------
+
+You can query any class's methods, instance variables, or other attributes using the methods provided. For example:
+
+    // get all subclasses of a class
+    NSArray *subclasses = [MyClass rt_subclasses];
+    
+    // check out the methods on NSString
+    NSArray *methods = [NSString rt_methods];
+    for(RTMethod *method in methods)
+        NSLog(@"%@", method);
+    
+    // does it have any ivars?
+    NSLog(@"%@", [NSString rt_ivars]);
+    
+    // how big is a constant string instance?
+    NSLog(@"%ld", (long)[[@"foo" rt_class] rt_instanceSize]);
+
+Modifying
+---------
+
+You can add new methods using `+rt_addMethod:`. You can modify the implementation of an existing method using the `-setImplementation:` method on `RTMethod`. Example:
+
+    // swizzle out -[NSObject description] (don't do this)
+    static NSString *NewDescription(id self, SEL _cmd)
+    {
+        return @"HELLO WORLD!";
+    }
+    
+    Method *description = [NSObject rt_methodForSelector: @selector(description)];
+    [description setImplementation: (IMP)NewDescription];
+
+You can create new classes using `+rt_createSubclassNamed:` or `+rt_createUnregisteredSubclassNamed:`. Note that if you want to add instance variables to a class then you have to use the Unregistered version, and add them before registering the class.
+
+Objects
+-------
+
+Two instance methods are provided as well. `-rt_class` exists because Apple likes to fiddle with the return value of `-class`, and `-rt_class` always gives you the right value. `-rt_setClass:` does pretty much what it says: sets the class of the object. It won't reallocate the object or anything, so the new class had better have a memory layout that's compatible with the old one, or else hilarity will ensue.
+
+Sending Messages
+----------------
+
+After getting a list of methods from a class, it's common to want to actually use those on instances of the class. `RTMethod` provides an easy method for doing this, as well as several convenience wrappers around it.
+
+The basic method for sending messages is `-[RTMethod returnValue:sendToTarget:]`. You use it like this:
+
+    RTMethod *method = ...;
+    SomeType ret;
+    [method returnValue: &ret sendToTarget: obj, RTARG(@"hello"), RTARG(42), RTARG(xyz)];
+
+It may seem odd to have the return value at the beginning of the argument list, but this comes closest to the order of the normal `ret = [obj method]` syntax.
+
+All arguments must be wrapped in the `RTARG` macro. This macro takes care of packaging up each argument so that it can survive passage through the variable argument list and also includes some extra metadata about the argument types so that the code can do some basic sanity checking. No automatic type conversions are performed. If you pass a `double` to a method that expects an `int`, this method will `abort`. That checking is only based on size, however, so if you pass a `float` where an `int` is expected, you'll just get a bad value.
+
+Note that while it's not 100% guaranteed, this code does a generally good job of detecting if you forgot to use the `RTARG` macro and warning you loudly and calling `abort` instead of simply crashing in a mysterious manner. Also note that there is no sanity checking on the return value, so it's your responsibility to ensure that you use the right type and have enough space to hold it.
+
+For methods which return an object, the `-[RTMethod sendToTarget:]` method is provided which directly returns `id` instead of making you use return-by-reference. This simplifies the calling of such methods:
+
+    RTMethod *method = ...;
+    id ret = [method sendToTarget: obj, RTARG(@"hello"), RTARG(42), RTARG(xyz)];
+
+There is also an `NSObject` category which provides methods that allows you to switch the order around to be more natural. For example:
+
+    RTMethod *method = ...;
+    id ret = [obj rt_sendMethod: method, RTARG(@"hello"), RTARG(42), RTARG(xyz)];
+
+And the same idea for `rt_returnValue:sendMethod:`.
+
+Finally, there are a pair of convenience methods that take a selector, and combine the method lookup with the actual message sending:
+
+    id ret = [obj rt_sendSelector: @selector(...), RTARG(@"hello"), RTARG(42), RTARG(xyz)];
+    SomeType ret2;
+    [obj rt_returnValue: &ret2 sendSelector: @selector(...), RTARG(12345)];

--- a/ios/ios/src/Vendor/RTIvar.h
+++ b/ios/ios/src/Vendor/RTIvar.h
@@ -1,0 +1,21 @@
+
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+
+
+@interface RTIvar : NSObject
+{
+}
+
++ (id)ivarWithObjCIvar: (Ivar)ivar;
++ (id)ivarWithName: (NSString *)name typeEncoding: (NSString *)typeEncoding;
++ (id)ivarWithName: (NSString *)name encode: (const char *)encodeStr;
+
+- (id)initWithObjCIvar: (Ivar)ivar;
+- (id)initWithName: (NSString *)name typeEncoding: (NSString *)typeEncoding;
+
+- (NSString *)name;
+- (NSString *)typeEncoding;
+- (ptrdiff_t)offset;
+
+@end

--- a/ios/ios/src/Vendor/RTIvar.m
+++ b/ios/ios/src/Vendor/RTIvar.m
@@ -1,0 +1,144 @@
+
+#import "RTIvar.h"
+
+
+@interface _RTObjCIvar : RTIvar
+{
+    Ivar _ivar;
+}
+@end
+
+@implementation _RTObjCIvar
+
+- (id)initWithObjCIvar: (Ivar)ivar
+{
+    if((self = [self init]))
+    {
+        _ivar = ivar;
+    }
+    return self;
+}
+- (NSString *)name
+{
+    return [NSString stringWithUTF8String: ivar_getName(_ivar)];
+}
+
+- (NSString *)typeEncoding
+{
+    return [NSString stringWithUTF8String: ivar_getTypeEncoding(_ivar)];
+}
+
+- (ptrdiff_t)offset
+{
+    return ivar_getOffset(_ivar);
+}
+
+@end
+
+@interface _RTComponentsIvar : RTIvar
+{
+    NSString *_name;
+    NSString *_typeEncoding;
+}
+@end
+
+@implementation _RTComponentsIvar
+
+- (id)initWithName: (NSString *)name typeEncoding: (NSString *)typeEncoding
+{
+    if((self = [self init]))
+    {
+        _name = [name copy];
+        _typeEncoding = [typeEncoding copy];
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    [_name release];
+    [_typeEncoding release];
+    [super dealloc];
+}
+
+- (NSString *)name
+{
+    return _name;
+}
+
+- (NSString *)typeEncoding
+{
+    return _typeEncoding;
+}
+
+- (ptrdiff_t)offset
+{
+    return -1;
+}
+
+@end
+
+@implementation RTIvar
+
++ (id)ivarWithObjCIvar: (Ivar)ivar
+{
+    return [[[self alloc] initWithObjCIvar: ivar] autorelease];
+}
+
++ (id)ivarWithName: (NSString *)name typeEncoding: (NSString *)typeEncoding
+{
+    return [[[self alloc] initWithName: name typeEncoding: typeEncoding] autorelease];
+}
+
++ (id)ivarWithName: (NSString *)name encode: (const char *)encodeStr
+{
+    return [self ivarWithName: name typeEncoding: [NSString stringWithUTF8String: encodeStr]];
+}
+
+- (id)initWithObjCIvar: (Ivar)ivar
+{
+    [self release];
+    return [[_RTObjCIvar alloc] initWithObjCIvar: ivar];
+}
+
+- (id)initWithName: (NSString *)name typeEncoding: (NSString *)typeEncoding
+{
+    return [[_RTComponentsIvar alloc] initWithName: name typeEncoding: typeEncoding];
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat: @"<%@ %p: %@ %@ %ld>", [self class], self, [self name], [self typeEncoding], (long)[self offset]];
+}
+
+- (BOOL)isEqual: (id)other
+{
+    return [other isKindOfClass: [RTIvar class]] &&
+           [[self name] isEqual: [other name]] &&
+           [[self typeEncoding] isEqual: [other typeEncoding]];
+}
+
+- (NSUInteger)hash
+{
+    return [[self name] hash] ^ [[self typeEncoding] hash];
+}
+
+- (NSString *)name
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return nil;
+}
+
+- (NSString *)typeEncoding
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return nil;
+}
+
+- (ptrdiff_t)offset
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return 0;
+}
+
+@end

--- a/ios/ios/src/Vendor/RTMethod.h
+++ b/ios/ios/src/Vendor/RTMethod.h
@@ -1,0 +1,47 @@
+
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+
+
+@interface RTMethod : NSObject
+{
+}
+
++ (id)methodWithObjCMethod: (Method)method;
++ (id)methodWithSelector: (SEL)sel implementation: (IMP)imp signature: (NSString *)signature;
+
+- (id)initWithObjCMethod: (Method)method;
+- (id)initWithSelector: (SEL)sel implementation: (IMP)imp signature: (NSString *)signature;
+
+- (SEL)selector;
+- (NSString *)selectorName;
+- (IMP)implementation;
+- (NSString *)signature;
+
+// for ObjC method instances, sets the underlying implementation
+// for selector/implementation/signature instances, just changes the pointer
+- (void)setImplementation: (IMP)newImp;
+
+// easy sending of arbitrary methods with arbitrary arguments
+// a simpler alternative to NSInvocation etc.
+// for simple cases where the return type is an id, use sendToTarget:
+// for others, use the returnValue: variant and pass a pointer to storage
+// (you can pass NULL if you don't care about the return value)
+// all arguments MUST BE WRAPPED in RTARG, e.g.:
+// [method sendToTarget: target, RTARG(arg1), RTARG(arg2)]
+#define RT_ARG_MAGIC_COOKIE 0xdeadbeef
+#define RTARG(expr) RT_ARG_MAGIC_COOKIE, @encode(__typeof__(expr)), (__typeof__(expr) []){ expr }
+- (id)sendToTarget: (id)target, ...;
+- (void)returnValue: (void *)retPtr sendToTarget: (id)target, ...;
+
+@end
+
+@interface NSObject (RTMethodSendingAdditions)
+
+- (id)rt_sendMethod: (RTMethod *)method, ...;
+- (void)rt_returnValue: (void *)retPtr sendMethod: (RTMethod *)method, ...;
+
+- (id)rt_sendSelector: (SEL)sel, ...;
+- (void)rt_returnValue: (void *)retPtr sendSelector: (SEL)sel, ...;
+
+@end

--- a/ios/ios/src/Vendor/RTMethod.m
+++ b/ios/ios/src/Vendor/RTMethod.m
@@ -1,0 +1,280 @@
+
+#import "RTMethod.h"
+
+#import <stdarg.h>
+
+#import "MARTNSObject.h"
+
+
+@interface _RTObjCMethod : RTMethod
+{
+    Method _m;
+}
+
+@end
+
+@implementation _RTObjCMethod
+
+- (id)initWithObjCMethod: (Method)method
+{
+    if((self = [self init]))
+    {
+        _m = method;
+    }
+    return self;
+}
+
+- (SEL)selector
+{
+    return method_getName(_m);
+}
+
+- (IMP)implementation
+{
+    return method_getImplementation(_m);
+}
+
+- (NSString *)signature
+{
+    return [NSString stringWithUTF8String: method_getTypeEncoding(_m)];
+}
+
+- (void)setImplementation: (IMP)newImp
+{
+    method_setImplementation(_m, newImp);
+}
+
+@end
+
+@interface _RTComponentsMethod : RTMethod
+{
+    SEL _sel;
+    IMP _imp;
+    NSString *_sig;
+}
+
+@end
+
+@implementation _RTComponentsMethod
+
+- (id)initWithSelector: (SEL)sel implementation: (IMP)imp signature: (NSString *)signature
+{
+    if((self = [self init]))
+    {
+        _sel = sel;
+        _imp = imp;
+        _sig = [signature copy];
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    [_sig release];
+    [super dealloc];
+}
+
+- (SEL)selector
+{
+    return _sel;
+}
+
+- (IMP)implementation
+{
+    return _imp;
+}
+
+- (NSString *)signature
+{
+    return _sig;
+}
+
+- (void)setImplementation: (IMP)newImp
+{
+    _imp = newImp;
+}
+
+@end
+
+@implementation RTMethod
+
++ (id)methodWithObjCMethod: (Method)method
+{
+    return [[[self alloc] initWithObjCMethod: method] autorelease];
+}
+
++ (id)methodWithSelector: (SEL)sel implementation: (IMP)imp signature: (NSString *)signature
+{
+    return [[[self alloc] initWithSelector: sel implementation: imp signature: signature] autorelease];
+}
+
+- (id)initWithObjCMethod: (Method)method
+{
+    [self release];
+    return [[_RTObjCMethod alloc] initWithObjCMethod: method];
+}
+
+- (id)initWithSelector: (SEL)sel implementation: (IMP)imp signature: (NSString *)signature
+{
+    [self release];
+    return [[_RTComponentsMethod alloc] initWithSelector: sel implementation: imp signature: signature];
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat: @"<%@ %p: %@ %p %@>", [self class], self, NSStringFromSelector([self selector]), [self implementation], [self signature]];
+}
+
+- (BOOL)isEqual: (id)other
+{
+    return [other isKindOfClass: [RTMethod class]] &&
+           [self selector] == [other selector] &&
+           [self implementation] == [other implementation] &&
+           [[self signature] isEqual: [other signature]];
+}
+
+- (NSUInteger)hash
+{
+    return (NSUInteger)[self selector] ^ (NSUInteger)[self implementation] ^ [[self signature] hash];
+}
+
+- (SEL)selector
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return NULL;
+}
+
+- (NSString *)selectorName
+{
+    return NSStringFromSelector([self selector]);
+}
+
+- (IMP)implementation
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return NULL;
+}
+
+- (NSString *)signature
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return NULL;
+}
+
+- (void)setImplementation: (IMP)newImp
+{
+    [self doesNotRecognizeSelector: _cmd];
+}
+
+- (void)_returnValue: (void *)retPtr sendToTarget: (id)target arguments: (va_list)args
+{
+    NSMethodSignature *signature = [target methodSignatureForSelector: [self selector]];
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature: signature];
+    NSUInteger argumentCount = [signature numberOfArguments];
+    
+    [invocation setTarget: target];
+    [invocation setSelector: [self selector]];
+    for(NSUInteger i = 2; i < argumentCount; i++)
+    {
+        int cookie = va_arg(args, int);
+        if(cookie != RT_ARG_MAGIC_COOKIE)
+        {
+            NSLog(@"%s: incorrect magic cookie %08x; did you forget to use RTARG() around your arguments?", __func__, cookie);
+            abort();
+        }
+        const char *typeStr = va_arg(args, char *);
+        void *argPtr = va_arg(args, void *);
+        
+        NSUInteger inSize;
+        NSGetSizeAndAlignment(typeStr, &inSize, NULL);
+        NSUInteger sigSize;
+        NSGetSizeAndAlignment([signature getArgumentTypeAtIndex: i], &sigSize, NULL);
+        
+        if(inSize != sigSize)
+        {
+            NSLog(@"%s: size mismatch between passed-in argument and required argument; in type: %s (%lu) requested: %s (%lu)", __func__, typeStr, (long)inSize, [signature getArgumentTypeAtIndex: i], (long)sigSize);
+            abort();
+        }
+        
+        [invocation setArgument: argPtr atIndex: i];
+    }
+    
+    [invocation invoke];
+    
+    if([signature methodReturnLength] && retPtr)
+        [invocation getReturnValue: retPtr];
+}
+
+- (id)sendToTarget: (id)target, ...
+{
+    NSParameterAssert([[self signature] hasPrefix: [NSString stringWithUTF8String: @encode(id)]]);
+    
+    id retVal;
+    
+    va_list args;
+    va_start(args, target);
+    [self _returnValue: &retVal sendToTarget: target arguments: args];
+    va_end(args);
+    
+    return retVal;
+}
+
+- (void)returnValue: (void *)retPtr sendToTarget: (id)target, ...
+{
+    va_list args;
+    va_start(args, target);
+    [self _returnValue: retPtr sendToTarget: target arguments: args];
+    va_end(args);
+}
+
+@end
+
+@implementation NSObject (RTMethodSendingAdditions)
+
+- (id)rt_sendMethod: (RTMethod *)method, ...
+{
+    NSParameterAssert([[method signature] hasPrefix: [NSString stringWithUTF8String: @encode(id)]]);
+    
+    id retVal;
+    
+    va_list args;
+    va_start(args, method);
+    [method _returnValue: &retVal sendToTarget: self arguments: args];
+    va_end(args);
+    
+    return retVal;
+}
+
+- (void)rt_returnValue: (void *)retPtr sendMethod: (RTMethod *)method, ...
+{
+    va_list args;
+    va_start(args, method);
+    [method _returnValue: retPtr sendToTarget: self arguments: args];
+    va_end(args);
+}
+
+- (id)rt_sendSelector: (SEL)sel, ...
+{
+    RTMethod *method = [[self rt_class] rt_methodForSelector: sel];
+    NSParameterAssert([[method signature] hasPrefix: [NSString stringWithUTF8String: @encode(id)]]);
+    
+    id retVal;
+    
+    va_list args;
+    va_start(args, sel);
+    [method _returnValue: &retVal sendToTarget: self arguments: args];
+    va_end(args);
+    
+    return retVal;
+}
+
+- (void)rt_returnValue: (void *)retPtr sendSelector: (SEL)sel, ...
+{
+    RTMethod *method = [[self rt_class] rt_methodForSelector: sel];
+    va_list args;
+    va_start(args, sel);
+    [method _returnValue: retPtr sendToTarget: self arguments: args];
+    va_end(args);
+}
+
+@end

--- a/ios/ios/src/Vendor/RTMethod.m
+++ b/ios/ios/src/Vendor/RTMethod.m
@@ -135,7 +135,7 @@
 
 - (NSUInteger)hash
 {
-    return (NSUInteger)[self selector] ^ (NSUInteger)[self implementation] ^ [[self signature] hash];
+    return (NSUInteger)(void *)[self selector] ^ (NSUInteger)[self implementation] ^ [[self signature] hash];
 }
 
 - (SEL)selector

--- a/ios/ios/src/Vendor/RTProperty.h
+++ b/ios/ios/src/Vendor/RTProperty.h
@@ -1,0 +1,57 @@
+
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+
+
+typedef enum
+{
+    RTPropertySetterSemanticsAssign,
+    RTPropertySetterSemanticsRetain,
+    RTPropertySetterSemanticsCopy
+}
+RTPropertySetterSemantics;
+
+@interface RTProperty : NSObject
+{
+}
+
++ (id)propertyWithObjCProperty: (objc_property_t)property;
++ (id)propertyWithName: (NSString *)name attributes:(NSDictionary *)attributes;
+
+- (id)initWithObjCProperty: (objc_property_t)property;
+- (id)initWithName: (NSString *)name attributes:(NSDictionary *)attributes;
+
+- (NSDictionary *)attributes;
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+- (BOOL)addToClass:(Class)classToAddTo;
+#endif
+
+- (NSString *)attributeEncodings;
+- (BOOL)isReadOnly;
+- (RTPropertySetterSemantics)setterSemantics;
+- (BOOL)isNonAtomic;
+- (BOOL)isDynamic;
+- (BOOL)isWeakReference;
+- (BOOL)isEligibleForGarbageCollection;
+- (SEL)customGetter;
+- (SEL)customSetter;
+- (NSString *)name;
+- (NSString *)typeEncoding;
+- (NSString *)oldTypeEncoding;
+- (NSString *)ivarName;
+
+@end
+
+extern NSString * const RTPropertyTypeEncodingAttribute;
+extern NSString * const RTPropertyBackingIVarNameAttribute;
+
+extern NSString * const RTPropertyCopyAttribute;
+extern NSString * const RTPropertyRetainAttribute;
+extern NSString * const RTPropertyCustomGetterAttribute;
+extern NSString * const RTPropertyCustomSetterAttribute;
+extern NSString * const RTPropertyDynamicAttribute;
+extern NSString * const RTPropertyEligibleForGarbageCollectionAttribute;
+extern NSString * const RTPropertyNonAtomicAttribute;
+extern NSString * const RTPropertyOldTypeEncodingAttribute;
+extern NSString * const RTPropertyReadOnlyAttribute;
+extern NSString * const RTPropertyWeakReferenceAttribute;

--- a/ios/ios/src/Vendor/RTProperty.m
+++ b/ios/ios/src/Vendor/RTProperty.m
@@ -1,0 +1,303 @@
+
+#import "RTProperty.h"
+
+
+@interface _RTObjCProperty : RTProperty
+{
+    objc_property_t _property;
+    NSMutableDictionary *_attrs;
+    NSString *_name;
+}
+@end
+
+@implementation _RTObjCProperty
+
+- (id)initWithObjCProperty: (objc_property_t)property
+{
+    if((self = [self init]))
+    {
+        _property = property;
+        NSArray *attrPairs = [[NSString stringWithUTF8String: property_getAttributes(property)] componentsSeparatedByString: @","];
+        _attrs = [[NSMutableDictionary alloc] initWithCapacity:[attrPairs count]];
+        for(NSString *attrPair in attrPairs)
+            [_attrs setObject:[attrPair substringFromIndex:1] forKey:[attrPair substringToIndex:1]];
+    }
+    return self;
+}
+
+- (id)initWithName: (NSString *)name attributes:(NSDictionary *)attributes
+{
+    if((self = [self init]))
+    {
+        _name = [name copy];
+        _attrs = [attributes copy];
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    [_attrs release];
+    [_name release];
+    [super dealloc];
+}
+
+- (NSString *)name
+{
+    if (_property)
+        return [NSString stringWithUTF8String: property_getName(_property)];
+    else
+        return _name;
+}
+
+- (NSDictionary *)attributes
+{
+    return [[_attrs copy] autorelease];
+}
+
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+- (BOOL)addToClass:(Class)classToAddTo
+{
+    NSDictionary *attrs = [self attributes];
+    objc_property_attribute_t *cattrs = (objc_property_attribute_t*)calloc([attrs count], sizeof(objc_property_attribute_t));
+    unsigned attrIdx = 0;
+    for (NSString *attrCode in attrs) {
+        cattrs[attrIdx].name = [attrCode UTF8String];
+        cattrs[attrIdx].value = [[attrs objectForKey:attrCode] UTF8String];
+        attrIdx++;
+    }
+    BOOL result = class_addProperty(classToAddTo,
+                                    [[self name] UTF8String],
+                                    cattrs,
+                                    [attrs count]);
+    free(cattrs);
+    return result;
+}
+#endif
+
+- (NSString *)attributeEncodings
+{
+    NSMutableArray *filteredAttributes = [NSMutableArray arrayWithCapacity:[_attrs count] - 2];
+    for (NSString *attrKey in _attrs)
+    {
+        if (![attrKey isEqualToString:RTPropertyTypeEncodingAttribute] && ![attrKey isEqualToString:RTPropertyBackingIVarNameAttribute])
+            [filteredAttributes addObject:[_attrs objectForKey:attrKey]];
+    }
+    return [filteredAttributes componentsJoinedByString: @","];
+}
+
+- (BOOL)hasAttribute: (NSString *)code
+{
+    return [_attrs objectForKey:code] != nil;
+}
+
+- (BOOL)isReadOnly
+{
+    return [self hasAttribute: RTPropertyReadOnlyAttribute];
+}
+
+- (RTPropertySetterSemantics)setterSemantics
+{
+    if([self hasAttribute: RTPropertyCopyAttribute]) return RTPropertySetterSemanticsCopy;
+    if([self hasAttribute: RTPropertyRetainAttribute]) return RTPropertySetterSemanticsRetain;
+    return RTPropertySetterSemanticsAssign;
+}
+
+- (BOOL)isNonAtomic
+{
+    return [self hasAttribute: RTPropertyNonAtomicAttribute];
+}
+
+- (BOOL)isDynamic
+{
+    return [self hasAttribute: RTPropertyDynamicAttribute];
+}
+
+- (BOOL)isWeakReference
+{
+    return [self hasAttribute: RTPropertyWeakReferenceAttribute];
+}
+
+- (BOOL)isEligibleForGarbageCollection
+{
+    return [self hasAttribute: RTPropertyEligibleForGarbageCollectionAttribute];
+}
+
+- (NSString *)contentOfAttribute: (NSString *)code
+{
+    return [_attrs objectForKey:code];
+}
+
+- (SEL)customGetter
+{
+    return NSSelectorFromString([self contentOfAttribute: RTPropertyCustomGetterAttribute]);
+}
+
+- (SEL)customSetter
+{
+    return NSSelectorFromString([self contentOfAttribute: RTPropertyCustomSetterAttribute]);
+}
+
+- (NSString *)typeEncoding
+{
+    return [self contentOfAttribute: RTPropertyTypeEncodingAttribute];
+}
+
+- (NSString *)oldTypeEncoding
+{
+    return [self contentOfAttribute: RTPropertyOldTypeEncodingAttribute];
+}
+
+- (NSString *)ivarName
+{
+    return [self contentOfAttribute: RTPropertyBackingIVarNameAttribute];
+}
+
+@end
+
+@implementation RTProperty
+
++ (id)propertyWithObjCProperty: (objc_property_t)property
+{
+    return [[[self alloc] initWithObjCProperty: property] autorelease];
+}
+
++ (id)propertyWithName: (NSString *)name attributes:(NSDictionary *)attributes
+{
+    return [[[self alloc] initWithName: name attributes: attributes] autorelease];
+}
+
+- (id)initWithObjCProperty: (objc_property_t)property
+{
+    [self release];
+    return [[_RTObjCProperty alloc] initWithObjCProperty: property];
+}
+
+- (id)initWithName: (NSString *)name attributes:(NSDictionary *)attributes
+{
+    [self release];
+    return [[_RTObjCProperty alloc] initWithName: name attributes: attributes];
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat: @"<%@ %p: %@ %@ %@ %@>", [self class], self, [self name], [self attributeEncodings], [self typeEncoding], [self ivarName]];
+}
+
+- (BOOL)isEqual: (id)other
+{
+    return [other isKindOfClass: [RTProperty class]] &&
+           [[self name] isEqual: [other name]] &&
+           ([self attributeEncodings] ? [[self attributeEncodings] isEqual: [other attributeEncodings]] : ![other attributeEncodings]) &&
+           [[self typeEncoding] isEqual: [other typeEncoding]] &&
+           ([self ivarName] ? [[self ivarName] isEqual: [other ivarName]] : ![other ivarName]);
+}
+
+- (NSUInteger)hash
+{
+    return [[self name] hash] ^ [[self typeEncoding] hash];
+}
+
+- (NSString *)name
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return nil;
+}
+
+- (NSDictionary *)attributes
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return nil;
+}
+
+- (BOOL)addToClass:(Class)classToAddTo
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return NO;
+}
+
+- (NSString *)attributeEncodings
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return nil;
+}
+
+- (BOOL)isReadOnly
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return NO;
+}
+- (RTPropertySetterSemantics)setterSemantics
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return RTPropertySetterSemanticsAssign;
+}
+
+- (BOOL)isNonAtomic
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return NO;
+}
+
+- (BOOL)isDynamic
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return NO;
+}
+
+- (BOOL)isWeakReference
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return NO;
+}
+
+- (BOOL)isEligibleForGarbageCollection
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return NO;
+}
+
+- (SEL)customGetter
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return (SEL)0;
+}
+
+- (SEL)customSetter
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return (SEL)0;
+}
+
+- (NSString *)typeEncoding
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return nil;
+}
+
+- (NSString *)oldTypeEncoding
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return nil;
+}
+
+- (NSString *)ivarName
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return nil;
+}
+
+@end
+
+NSString * const RTPropertyTypeEncodingAttribute                  = @"T";
+NSString * const RTPropertyBackingIVarNameAttribute               = @"V";
+NSString * const RTPropertyCopyAttribute                          = @"C";
+NSString * const RTPropertyCustomGetterAttribute                  = @"G";
+NSString * const RTPropertyCustomSetterAttribute                  = @"S";
+NSString * const RTPropertyDynamicAttribute                       = @"D";
+NSString * const RTPropertyEligibleForGarbageCollectionAttribute  = @"P";
+NSString * const RTPropertyNonAtomicAttribute                     = @"N";
+NSString * const RTPropertyOldTypeEncodingAttribute               = @"t";
+NSString * const RTPropertyReadOnlyAttribute                      = @"R";
+NSString * const RTPropertyRetainAttribute                        = @"&";
+NSString * const RTPropertyWeakReferenceAttribute                 = @"W";

--- a/ios/ios/src/Vendor/RTProtocol.h
+++ b/ios/ios/src/Vendor/RTProtocol.h
@@ -1,0 +1,23 @@
+
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+
+
+@interface RTProtocol : NSObject
+{
+}
+
++ (NSArray *)allProtocols;
+
++ (id)protocolWithObjCProtocol: (Protocol *)protocol;
++ (id)protocolWithName: (NSString *)name;
+
+- (id)initWithObjCProtocol: (Protocol *)protocol;
+- (id)initWithName: (NSString *)name;
+
+- (Protocol *)objCProtocol;
+- (NSString *)name;
+- (NSArray *)incorporatedProtocols;
+- (NSArray *)methodsRequired: (BOOL)isRequiredMethod instance: (BOOL)isInstanceMethod;
+
+@end

--- a/ios/ios/src/Vendor/RTProtocol.m
+++ b/ios/ios/src/Vendor/RTProtocol.m
@@ -1,0 +1,122 @@
+
+#import "RTProtocol.h"
+#import "RTMethod.h"
+
+
+@interface _RTObjCProtocol : RTProtocol
+{
+    Protocol *_protocol;
+}
+@end
+
+@implementation _RTObjCProtocol
+
+- (id)initWithObjCProtocol: (Protocol *)protocol
+{
+    if((self = [self init]))
+    {
+        _protocol = protocol;
+    }
+    return self;
+}
+
+- (Protocol *)objCProtocol
+{
+    return _protocol;
+}
+
+@end
+
+@implementation RTProtocol
+
++ (NSArray *)allProtocols
+{
+    unsigned int count;
+    Protocol **protocols = objc_copyProtocolList(&count);
+    
+    NSMutableArray *array = [NSMutableArray array];
+    for(unsigned i = 0; i < count; i++)
+        [array addObject: [[[self alloc] initWithObjCProtocol: protocols[i]] autorelease]];
+    
+    free(protocols);
+    return array;
+}
+
++ (id)protocolWithObjCProtocol: (Protocol *)protocol
+{
+    return [[[self alloc] initWithObjCProtocol: protocol] autorelease];
+}
+
++ (id)protocolWithName: (NSString *)name
+{
+    return [[[self alloc] initWithName: name] autorelease];
+}
+
+- (id)initWithObjCProtocol: (Protocol *)protocol
+{
+    [self release];
+    return [[_RTObjCProtocol alloc] initWithObjCProtocol: protocol];
+}
+
+- (id)initWithName: (NSString *)name
+{
+    return [self initWithObjCProtocol:objc_getProtocol([name cStringUsingEncoding:[NSString defaultCStringEncoding]])];
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat: @"<%@ %p: %@>", [self class], self, [self name]];
+}
+
+- (BOOL)isEqual: (id)other
+{
+    return [other isKindOfClass: [RTProtocol class]] &&
+           protocol_isEqual([self objCProtocol], [other objCProtocol]);
+}
+
+- (NSUInteger)hash
+{
+    return [[self objCProtocol] hash];
+}
+
+- (Protocol *)objCProtocol
+{
+    [self doesNotRecognizeSelector: _cmd];
+    return nil;
+}
+
+- (NSString *)name
+{
+    return [NSString stringWithUTF8String: protocol_getName([self objCProtocol])];
+}
+
+- (NSArray *)incorporatedProtocols
+{
+    unsigned int count;
+    Protocol **protocols = protocol_copyProtocolList([self objCProtocol], &count);
+    
+    NSMutableArray *array = [NSMutableArray array];
+    for(unsigned i = 0; i < count; i++)
+        [array addObject: [RTProtocol protocolWithObjCProtocol: protocols[i]]];
+    
+    free(protocols);
+    return array;
+}
+
+- (NSArray *)methodsRequired: (BOOL)isRequiredMethod instance: (BOOL)isInstanceMethod
+{
+    unsigned int count;
+    struct objc_method_description *methods = protocol_copyMethodDescriptionList([self objCProtocol], isRequiredMethod, isInstanceMethod, &count);
+    
+    NSMutableArray *array = [NSMutableArray array];
+    for(unsigned i = 0; i < count; i++)
+    {
+        NSString *signature = [NSString stringWithCString: methods[i].types encoding: [NSString defaultCStringEncoding]];
+        [array addObject: [RTMethod methodWithSelector: methods[i].name implementation: NULL signature: signature]];
+    }
+    
+    free(methods);
+    return array;
+}
+
+@end

--- a/ios/ios/src/Vendor/RTUnregisteredClass.h
+++ b/ios/ios/src/Vendor/RTUnregisteredClass.h
@@ -1,0 +1,30 @@
+
+#import <Foundation/Foundation.h>
+
+
+@class RTProtocol;
+@class RTIvar;
+@class RTMethod;
+@class RTProperty;
+
+@interface RTUnregisteredClass : NSObject
+{
+    Class _class;
+}
+
++ (id)unregisteredClassWithName: (NSString *)name withSuperclass: (Class)superclass;
++ (id)unregisteredClassWithName: (NSString *)name;
+
+- (id)initWithName: (NSString *)name withSuperclass: (Class)superclass;
+- (id)initWithName: (NSString *)name;
+
+- (void)addProtocol: (RTProtocol *)protocol;
+- (void)addIvar: (RTIvar *)ivar;
+- (void)addMethod: (RTMethod *)method;
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+- (void)addProperty: (RTProperty *)property;
+#endif
+
+- (Class)registerClass;
+
+@end

--- a/ios/ios/src/Vendor/RTUnregisteredClass.m
+++ b/ios/ios/src/Vendor/RTUnregisteredClass.m
@@ -1,0 +1,72 @@
+
+#import "RTUnregisteredClass.h"
+
+#import "RTProtocol.h"
+#import "RTIvar.h"
+#import "RTMethod.h"
+#import "RTProperty.h"
+
+
+@implementation RTUnregisteredClass
+
++ (id)unregisteredClassWithName: (NSString *)name withSuperclass: (Class)superclass
+{
+    return [[[self alloc] initWithName: name withSuperclass: superclass] autorelease];
+}
+
++ (id)unregisteredClassWithName: (NSString *)name
+{
+    return [self unregisteredClassWithName: name withSuperclass: Nil];
+}
+
+- (id)initWithName: (NSString *)name withSuperclass: (Class)superclass
+{
+    if((self = [self init]))
+    {
+        _class = objc_allocateClassPair(superclass, [name UTF8String], 0);
+        if(_class == Nil)
+        {
+            [self release];
+            return nil;
+        }
+    }
+    return self;
+}
+
+- (id)initWithName: (NSString *)name
+{
+    return [self initWithName: name withSuperclass: Nil];
+}
+
+- (void)addProtocol: (RTProtocol *)protocol
+{
+    class_addProtocol(_class, [protocol objCProtocol]);
+}
+
+- (void)addIvar: (RTIvar *)ivar
+{
+    const char *typeStr = [[ivar typeEncoding] UTF8String];
+    NSUInteger size, alignment;
+    NSGetSizeAndAlignment(typeStr, &size, &alignment);
+    class_addIvar(_class, [[ivar name] UTF8String], size, log2(alignment), typeStr);
+}
+
+- (void)addMethod: (RTMethod *)method
+{
+    class_addMethod(_class, [method selector], [method implementation], [[method signature] UTF8String]);
+}
+
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+- (void)addProperty: (RTProperty *)property
+{
+    [property addToClass:_class];
+}
+#endif
+
+- (Class)registerClass
+{
+    objc_registerClassPair(_class);
+    return _class;
+}
+
+@end


### PR DESCRIPTION
The pod version of this dependency appears abandoned and is building with warnings. It appears unlikely, based CocoaPods usage reports, that any client app would have another dependency using this one. This PR vendors in the dependency and fixes the warning. In the long run, it might be wise to extract just the needed functionality from this library and implement it in internal classes.